### PR TITLE
Fix DOM_RET_OBJ calls for 8.4

### DIFF
--- a/php_xmldiff.h
+++ b/php_xmldiff.h
@@ -190,7 +190,9 @@ php_xmldiff_do_diff_memory(const char *from, size_t from_len, const char *to, si
 PHP_XMLDIFF_API xmlChar *
 php_xmldiff_do_merge_memory(const char *src, size_t src_len, const char *diff, size_t diff_len, struct ze_xmldiff_obj *zxo TSRMLS_DC);
 
-#if PHP_MAJOR_VERSION >= 7 || PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION > 3
+#if PHP_MAJOR_VERSION > 8 || PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION > 3
+#  define XMLDIFF_DOM_RET_OBJ(obj, ret, domobject) DOM_RET_OBJ(obj, domobject)
+#elif PHP_MAJOR_VERSION >= 7 || PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION > 3
 #  define XMLDIFF_DOM_RET_OBJ DOM_RET_OBJ
 #elif PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION == 3 && PHP_RELEASE_VERSION > 6
 #  define XMLDIFF_DOM_RET_OBJ DOM_RET_OBJ_EX


### PR DESCRIPTION
From `UPGRADING.INTERNALS`
```
   - Removed the `ret` argument from the DOM_RET_OBJ macro, use the return
     value instead.
```

Notice: was already using `return_value` by default (at least since 7.0), because of strange macro def.

```
#define DOM_RET_OBJ(obj, ret, domobject) \
	*ret = php_dom_create_object(obj, return_value, domobject)

```
