### PR TITLE
Fix memory leaks

### DIFF
--- a/diffmark/lib/diff.cc
+++ b/diffmark/lib/diff.cc
@@ -358,15 +358,13 @@ void Diff::on_delete(xmlNodePtr n)
 
 xmlNodePtr Diff::new_dm_node(const char *name)
 {
-    xmlNodePtr n = xmlNewNode(dest_ns,
-	reinterpret_cast<const xmlChar *>(name));
+    xmlNodePtr n = xmlNewDocNode(dest, dest_ns,
+	reinterpret_cast<const xmlChar *>(name), nullptr);
     if (!n) {
 	string s = "cannot create ";
 	s += name;
 	throw s;
     }
-
-    xmlSetTreeDoc(n, dest);
 
     return n;
 }

--- a/diffmark/lib/merge.cc
+++ b/diffmark/lib/merge.cc
@@ -174,7 +174,12 @@ void Merge::copy_shallow(xmlNodePtr tip)
     assert(src_point);
 
     xmlNodePtr n = import_tip(tip);
-    purge_dm(n);
+    try {
+        purge_dm(n);
+    } catch (...) {
+        xmlFreeNode(n);
+        throw;
+    }
     append(n);
 
     xmlNodePtr checked_child = src_point->children;

--- a/diffmark/lib/target.cc
+++ b/diffmark/lib/target.cc
@@ -37,15 +37,11 @@ xmlNodePtr Target::do_import_node(xmlNodePtr n)
     assert(n->type != XML_DTD_NODE);
     assert(n->type != XML_ENTITY_REF_NODE);
 
-    xmlNodePtr nn = xmlCopyNode(n, 1);
-    if (!nn) {
-	throw string("cannot copy node");
-    }
-
     XDoc dest = get_dest();
 
-    if (n->doc != (xmlDocPtr)dest) {
-	xmlSetTreeDoc(nn, dest);
+    xmlNodePtr nn = xmlDocCopyNode(n, dest, 1);
+    if (!nn) {
+	throw string("cannot copy node");
     }
 
     return nn;

--- a/diffmark/lib/xutil.cc
+++ b/diffmark/lib/xutil.cc
@@ -221,11 +221,15 @@ void xutil::remove_child(xmlNodePtr parent, xmlNodePtr child)
 
 void xutil::remove_children(xmlNodePtr n)
 {
-    if (n->children)
-    {
-	xmlFree(n->children);
-	n->children = 0;
-	n->last = 0;
+    xmlNodePtr cur = n->children;
+    if (cur) {
+        while (cur) {
+            xmlNodePtr next = cur->next;
+            xmlFreeNode(cur);
+            cur = next;
+        }
+        n->children = 0;
+        n->last = 0;
     }
 }
 

--- a/diffmark/lib/xutil.cc
+++ b/diffmark/lib/xutil.cc
@@ -216,6 +216,7 @@ void xutil::remove_child(xmlNodePtr parent, xmlNodePtr child)
 	(parent == child->parent));
 
     unlink_node(child);
+    xmlFreeNode(child);
 }
 
 void xutil::remove_children(xmlNodePtr n)

--- a/xmldiff.cpp
+++ b/xmldiff.cpp
@@ -378,34 +378,22 @@ PHP_XMLDIFF_API xmlDocPtr
 php_xmldiff_do_diff_doc(xmlDocPtr fromXmlDoc, xmlDocPtr toXmlDoc, struct ze_xmldiff_obj *zxo TSRMLS_DC)
 {/*{{{*/
 	xmlDocPtr retDoc = NULL;
-	XDoc *xFrom = NULL, *xTo = NULL, xDiff;
+	XDoc xDiff;
+	XDoc xFrom(fromXmlDoc);
+	XDoc xTo(toXmlDoc);
 
 	try {
-
-		xFrom = new XDoc(fromXmlDoc);
-		xTo = new XDoc(toXmlDoc);
-
-		if (NULL != xFrom && NULL != xTo) {
-			xDiff = php_xmldiff_do_diff(*xFrom, *xTo, zxo TSRMLS_CC);
-			retDoc = xDiff.yank();
-		}
-
+		xDiff = php_xmldiff_do_diff(xFrom, xTo, zxo TSRMLS_CC);
+		retDoc = xDiff.yank();
 	} catch (std::bad_alloc &x) {
-		if (NULL != xFrom) {
-			delete xFrom;
-		}
-		if (NULL != xTo) {
-			delete xTo;
-		}
-
 		php_xmldiff_throw_exception_no_va(x.what(), PHP_XMLDIFF_THROW_BADALLOC TSRMLS_CC);
-
-		return NULL;
 	} catch (std::string &x) {
 		php_xmldiff_throw_exception_no_va(x.c_str(), PHP_XMLDIFF_THROW_DIFF TSRMLS_CC);
-
-		return NULL;
 	}
+
+	// Non-owned, so destructor should not clean the internal documents.
+	xFrom.yank();
+	xTo.yank();
 
 	return retDoc;
 }/*}}}*/
@@ -414,33 +402,22 @@ PHP_XMLDIFF_API xmlDocPtr
 php_xmldiff_do_merge_doc(xmlDocPtr srcXmlDoc, xmlDocPtr diffXmlDoc, struct ze_xmldiff_obj *zxo TSRMLS_DC)
 {/*{{{*/
 	xmlDocPtr retDoc = NULL;
-	XDoc *xSrc = NULL, *xDiff = NULL, xMerge;
+	XDoc xMerge;
+	XDoc xSrc(srcXmlDoc);
+	XDoc xDiff(diffXmlDoc);
 
 	try {
-
-		xSrc = new XDoc(srcXmlDoc);
-		xDiff = new XDoc(diffXmlDoc);
-
-		if (NULL != xSrc && NULL != xDiff) {
-			xMerge = php_xmldiff_do_merge(*xSrc, *xDiff, zxo TSRMLS_CC);
-			retDoc = xMerge.yank();
-		}
+		xMerge = php_xmldiff_do_merge(xSrc, xDiff, zxo TSRMLS_CC);
+		retDoc = xMerge.yank();
 	} catch (std::bad_alloc &x) {
-		if (NULL != xSrc) {
-			delete xSrc;
-		}
-		if (NULL != xDiff) {
-			delete xDiff;
-		}
-
 		php_xmldiff_throw_exception_no_va(x.what(), PHP_XMLDIFF_THROW_BADALLOC TSRMLS_CC);
-
-		return NULL;
 	} catch (std::string &x) {
 		php_xmldiff_throw_exception_no_va(x.c_str(), PHP_XMLDIFF_THROW_MERGE TSRMLS_CC);
-
-		return NULL;
 	}
+
+	// Non-owned, so destructor should not clean the internal documents.
+	xSrc.yank();
+	xDiff.yank();
 
 	return retDoc;
 }/*}}}*/

--- a/xmldiff.cpp
+++ b/xmldiff.cpp
@@ -482,7 +482,11 @@ php_xmldiff_do_diff_memory(const char *from, size_t from_len, const char *to, si
 	if (NULL != fromXmlDoc && NULL != toXmlDoc) {
 		retDoc = php_xmldiff_do_diff_doc(fromXmlDoc, toXmlDoc, zxo TSRMLS_CC);
 		xmlDocDumpFormatMemory(retDoc, &ret, &size, 1);
+		xmlFreeDoc(retDoc);
 	}
+
+	xmlFreeDoc(fromXmlDoc);
+	xmlFreeDoc(toXmlDoc);
 
 	return ret;
 }/*}}}*/
@@ -499,7 +503,11 @@ php_xmldiff_do_merge_memory(const char *src, size_t src_len, const char *diff, s
 	if (NULL != srcXmlDoc && NULL != diffXmlDoc) {
 		retDoc = php_xmldiff_do_merge_doc(srcXmlDoc, diffXmlDoc, zxo TSRMLS_CC);
 		xmlDocDumpFormatMemory(retDoc, &ret, &size, 1);
+		xmlFreeDoc(retDoc);
 	}
+
+	xmlFreeDoc(srcXmlDoc);
+	xmlFreeDoc(diffXmlDoc);
 
 	return ret;
 }/*}}}*/


### PR DESCRIPTION
If you run the test suite under ASAN, you'll see hundreds of leaks. These are leaks of the bad kind: they're from persistently allocated memory.

There were some leaks in the diffmark library as well, but unfortunately upstream no longer exists so we fix it here.

With this PR, there are no longer any leaks.