### PR TITLE
Avoid a lot of string allocations

### DIFF
--- a/diffmark/lib/diff.cc
+++ b/diffmark/lib/diff.cc
@@ -89,7 +89,7 @@ Diff::Diff(const std::string &nsprefix, const std::string &nsurl):
 {
 }
 
-string Diff::get_ns_prefix() const
+const string &Diff::get_ns_prefix() const
 {
     return nsprefix;
 }
@@ -185,7 +185,7 @@ void Diff::descend(xmlNodePtr m, xmlNodePtr n)
 
     xmlNodePtr last = seq->last;
     if (last &&
-	(get_node_name(last) == get_scoped_name("delete"))) {
+	equals_scoped_name(last, "delete")) {
 	prune(last);
     }
 }
@@ -235,8 +235,8 @@ bool Diff::combine_pair(xmlNodePtr n, bool reverse)
 	remove_child(last, moved);
     }
 
-    if (combine_first_child(ch, get_scoped_name("delete")) ||
-	combine_first_child(ch, get_scoped_name("insert"))) {
+    if (combine_first_child(ch, "delete") ||
+	combine_first_child(ch, "insert")) {
 	ch = ch->next;
     }
 
@@ -251,15 +251,15 @@ bool Diff::combine_pair(xmlNodePtr n, bool reverse)
 }
 
 bool Diff::combine_first_child(xmlNodePtr first_child,
-    const std::string &checked_name)
+    const char *checked_name)
 {
     xmlNodePtr last = dest_point->last;
     if (!last) {
 	return false;
     }
 
-    if ((get_node_name(last) != checked_name) ||
-	(get_node_name(first_child) != checked_name)) {
+    if (!equals_scoped_name(last, checked_name) ||
+	!equals_scoped_name(first_child, checked_name)) {
 	return false;
     }
 
@@ -302,8 +302,8 @@ void Diff::on_match()
     xmlNodePtr last = dest_point->last;
     if (!last) {
 	append_copy();
-    } else if (get_node_name(last) != get_scoped_name("copy")) {
-	if (get_node_name(last) == get_scoped_name("delete")) {
+    } else if (!equals_scoped_name(last, "copy")) {
+	if (equals_scoped_name(last, "delete")) {
 	    prune(last);
 	}
 	append_copy();
@@ -325,9 +325,9 @@ void Diff::on_insert(xmlNodePtr n)
     xmlNodePtr last = dest_point->last;
     if (!last) {
 	append_insert(n);
-    } else if (get_node_name(last) == get_scoped_name("insert")) {
+    } else if (equals_scoped_name(last, "insert")) {
 	append_child(last, import_node(n));
-    } else if (get_node_name(last) != get_scoped_name("delete")) {
+    } else if (!equals_scoped_name(last, "delete")) {
 	append_insert(n);
     } else {
 	if (!combine_pair(n, false)) {
@@ -344,10 +344,10 @@ void Diff::on_delete(xmlNodePtr n)
     xmlNodePtr last = dest_point->last;
     if (!last) {
 	append_delete(n);
-    } else if (get_node_name(last) == get_scoped_name("delete")) {
+    } else if (equals_scoped_name(last, "delete")) {
 	prune(last);
 	append_child(last, import_node(n));
-    } else if (get_node_name(last) != get_scoped_name("insert")) {
+    } else if (!equals_scoped_name(last, "insert")) {
 	append_delete(n);
     } else {
 	if (!combine_pair(n, true)) {

--- a/diffmark/lib/diff.hh
+++ b/diffmark/lib/diff.hh
@@ -39,7 +39,7 @@ public:
     xmlDocPtr diff_nodes(xmlNodePtr m, xmlNodePtr n);
 
 protected:
-    virtual std::string get_ns_prefix() const;
+    virtual const std::string &get_ns_prefix() const;
     virtual XDoc get_dest();
 
 private:    
@@ -61,7 +61,7 @@ private:
     bool combine_pair(xmlNodePtr n, bool reverse);
 
     bool combine_first_child(xmlNodePtr first_child,
-	const std::string &checked_name);
+	const char *checked_name);
 
     void append_insert(xmlNodePtr n);
     void append_delete(xmlNodePtr n);

--- a/diffmark/lib/merge.cc
+++ b/diffmark/lib/merge.cc
@@ -52,7 +52,7 @@ xmlDocPtr Merge::merge(xmlNodePtr diff_node)
     return dest.yank();
 }
 
-std::string Merge::get_ns_prefix() const
+const std::string &Merge::get_ns_prefix() const
 {
     assert(!nsprefix.empty()); // don't call this function too soon
     return nsprefix;
@@ -67,14 +67,13 @@ void Merge::do_merge(xmlNodePtr tree)
 {
     assert(tree);
 
-    string name = get_node_name(tree);
-    TRACE("do_merge(" << name << ')');
+    TRACE("do_merge(" << get_node_name(tree) << ')');
 
-    if (name == get_scoped_name("delete")) {
+    if (equals_scoped_name(tree, "delete")) {
 	handle_delete(tree);
-    } else if (name == get_scoped_name("copy")) {
+    } else if (equals_scoped_name(tree, "copy")) {
 	handle_copy(tree);
-    } else if (name == get_scoped_name("insert")) {
+    } else if (equals_scoped_name(tree, "insert")) {
 	handle_insert(tree);
     } else {
 	if (tree->ns &&
@@ -279,10 +278,9 @@ string Merge::init_ns_prefix(xmlNodePtr diff_node)
 
 void Merge::check_top_node_name(xmlNodePtr diff_node)
 {
-    string actual = get_node_name(diff_node);
-    if (actual != get_scoped_name("diff")) {
+    if (!equals_scoped_name(diff_node, "diff")) {
 	string s = "invalid document node ";
-	s += actual;
+	s += get_node_name(diff_node);
 	throw s;
     }
 }

--- a/diffmark/lib/merge.hh
+++ b/diffmark/lib/merge.hh
@@ -16,7 +16,7 @@ public:
     xmlDocPtr merge(xmlNodePtr diff_node);
 
 protected:
-    virtual std::string get_ns_prefix() const;
+    virtual const std::string &get_ns_prefix() const;
     virtual XDoc get_dest();
 
 private:

--- a/diffmark/lib/target.cc
+++ b/diffmark/lib/target.cc
@@ -1,5 +1,6 @@
 #include "target.hh"
 #include "xdoc.hh"
+#include "xutil.hh"
 #include <iostream>
 #include <stdlib.h>
 #include <assert.h>
@@ -23,6 +24,11 @@ string Target::get_scoped_name(const char *tail)
     name += ':';
     name += tail;
     return name;
+}
+
+bool Target::equals_scoped_name(const xmlNode *n, const char *tail) const
+{
+    return xutil::node_name_equals(n, get_ns_prefix().c_str(), tail);
 }
 
 xmlNodePtr Target::import_node(xmlNodePtr n)

--- a/diffmark/lib/target.hh
+++ b/diffmark/lib/target.hh
@@ -12,12 +12,13 @@ protected:
     Target(const std::string &nsurl);
 
     std::string get_scoped_name(const char *tail);
-    std::string get_ns_url();
+    bool equals_scoped_name(const xmlNode *n, const char *tail) const;
+    const std::string &get_ns_url();
 
     xmlNodePtr import_node(xmlNodePtr n);
     xmlNodePtr import_tip(xmlNodePtr n);
 
-    virtual std::string get_ns_prefix() const = 0;
+    virtual const std::string &get_ns_prefix() const = 0;
     virtual XDoc get_dest() = 0;
 
     static int get_count_attr(xmlNodePtr instr);
@@ -28,7 +29,7 @@ private:
     xmlNodePtr do_import_node(xmlNodePtr n);
 };
 
-inline std::string Target::get_ns_url()
+inline const std::string &Target::get_ns_url()
 {
     return nsurl;
 }

--- a/diffmark/lib/xutil.cc
+++ b/diffmark/lib/xutil.cc
@@ -186,6 +186,15 @@ string xutil::get_node_name(xmlNodePtr n)
     return out;
 }
 
+bool xutil::node_name_equals(const xmlNode *n, const char *prefix, const char *local_name)
+{
+    if (!n->ns) {
+        return false;
+    }
+    return xmlStrEqual(n->name, reinterpret_cast<const xmlChar *>(local_name))
+        && xmlStrEqual(n->ns->prefix, reinterpret_cast<const xmlChar *>(prefix));
+}
+
 void xutil::append_child(xmlNodePtr ex_parent, xmlNodePtr new_child)
 {
     assert(ex_parent != 0);

--- a/diffmark/lib/xutil.hh
+++ b/diffmark/lib/xutil.hh
@@ -17,6 +17,8 @@ XDoc parse_file(const char *fname);
 
 std::string get_node_name(xmlNodePtr n);
 
+bool node_name_equals(const xmlNode *n, const char *prefix, const char *local_name);
+
 void append_child(xmlNodePtr ex_parent, xmlNodePtr new_child);
 
 void remove_child(xmlNodePtr parent, xmlNodePtr child);


### PR DESCRIPTION
These allocations were necessary to compare the names of nodes with predefines names, but we can do that without allocation by introducing new helpers. These helpers just compare the prefix and local name directly.